### PR TITLE
Reversed a word with precomputed cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.exe
+.vscode/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "intelliSenseMode": "windows-msvc-x64",
+            "compilerPath": "C:/msys64/mingw64/bin/gcc.exe"
+        }
+    ],
+    "version": 4
+}

--- a/reverseWord/reverseWord.c
+++ b/reverseWord/reverseWord.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main()
+{
+    return(0);
+}

--- a/reverseWord/reverseWord.c
+++ b/reverseWord/reverseWord.c
@@ -1,6 +1,23 @@
-#include<stdio.h>
+#include <stdio.h>
+
+void rev(short x)
+{
+    const short KeyLength = 4;
+    const short bitmask = 0x0f;                                // 00000000 00000111
+    const short precomputedCache[] = {0x00, 0x08, 0x04, 0x0c, 0x02, 0x0a, 0x06, 0x0e, 0x01, 0x09, 0x05, 0x0d, 0x03, 0x0b, 0x07, 0x0f}; // 0000 1000 0100 1100 0010 1010 0110 1110 0001 1001 0101 1101 0011 1011 0111 1111
+    short result = precomputedCache[(x & bitmask)] << 3 * KeyLength |
+                   precomputedCache[(x >> KeyLength) & bitmask] << 2 * KeyLength |
+                   precomputedCache[(x >> (2 * KeyLength)) & bitmask] << KeyLength |
+                   precomputedCache[(x >> (3 * KeyLength)) & bitmask];
+
+    printf("%hu\n", result);
+}
 
 int main()
 {
-    return(0);
+    rev(1); // output 32768
+    rev(0); // output 0
+    rev(10); // output 20480
+    getchar();
+    return (0);
 }


### PR DESCRIPTION
Input type: short
Output: reversed the word in binary form

Uses precomputed cache of reversed nibble combinations. 
Uses simple shift and OR operations to compute reverse. Completes in O(n/L) time complexity where n is word length and L is keyword length.